### PR TITLE
feat: display training info and performance in UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ python src/onnx_infer.py --prompt "Create order 555 for user Alice totaling 123.
 
 # 6) Offline UI
 python src/ui.py   # open http://127.0.0.1:7860
+# The interface displays training metrics, generation speed, and keeps a
+# history of prompts with their XML outputs for easy verification.
 ```
 
 Note: Don't commit trained weights; they're ignored by .gitignore. Use Releases/artifacts if you need to share binaries internally.

--- a/src/ui.py
+++ b/src/ui.py
@@ -1,3 +1,7 @@
+import json
+import time
+from typing import List
+
 import gradio as gr
 from pathlib import Path
 from optimum.onnxruntime import ORTModelForSeq2Seq
@@ -22,26 +26,54 @@ def _load_backend():
     return mdl, tok, "Torch"
 
 
+def _load_training_metrics() -> str:
+    trainer_state = Path(MODEL_DIR) / "trainer_state.json"
+    if not trainer_state.exists():
+        return "Training metrics not available."
+    with trainer_state.open() as f:
+        state = json.load(f)
+    train_loss = None
+    eval_loss = None
+    for entry in state.get("log_history", []):
+        if "train_loss" in entry:
+            train_loss = entry["train_loss"]
+        if "eval_loss" in entry:
+            eval_loss = entry["eval_loss"]
+    metrics = []
+    if train_loss is not None:
+        metrics.append(f"train_loss: {train_loss:.4f}")
+    if eval_loss is not None:
+        metrics.append(f"eval_loss: {eval_loss:.4f}")
+    return "Training metrics - " + ", ".join(metrics)
+
+
 MODEL, TOKENIZER, BACKEND = _load_backend()
+TRAINING_INFO = _load_training_metrics()
 
 
-def generate_and_validate(prompt: str, schema: str):
+def generate_and_validate(prompt: str, schema: str, history: List[List[str]]):
     if not prompt.strip():
-        return "", "Please enter a prompt.", f"(Backend: {BACKEND})"
+        return "", "Please enter a prompt.", f"(Backend: {BACKEND})", "", history
+    start = time.perf_counter()
     inputs = TOKENIZER(f"to-xml: {prompt}", return_tensors="pt")
     out_ids = MODEL.generate(**inputs, max_length=160, num_beams=4)
     xml = TOKENIZER.decode(out_ids[0], skip_special_tokens=True)
     xsd_path = str((SCHEMA_DIR / f"{schema}.xsd").resolve())
     ok, err = validate_xml(xml, xsd_path)
+    duration = time.perf_counter() - start
+    history.append([prompt, xml])
     return (
         pretty(xml) if ok else xml,
         "VALID ✅" if ok else f"INVALID ❌: {err}",
         f"(Backend: {BACKEND})",
+        f"Generation time: {duration:.3f}s",
+        history,
     )
 
 
 with gr.Blocks(title="Offline XML Generator") as app:
     gr.Markdown("# Offline XML Generator")
+    gr.Markdown(TRAINING_INFO)
     with gr.Row():
         prompt = gr.Textbox(label="Prompt")
         schema = gr.Dropdown(choices=["user", "product", "order"], value="user", label="Schema")
@@ -49,7 +81,14 @@ with gr.Blocks(title="Offline XML Generator") as app:
     xml_out = gr.Code(label="Generated XML", language="xml")
     status = gr.Markdown()
     backend = gr.Markdown()
-    submit.click(fn=generate_and_validate, inputs=[prompt, schema], outputs=[xml_out, status, backend])
+    perf = gr.Markdown()
+    history_state = gr.State([])
+    history_view = gr.Dataframe(headers=["Prompt", "XML"], label="History", interactive=False)
+    submit.click(
+        fn=generate_and_validate,
+        inputs=[prompt, schema, history_state],
+        outputs=[xml_out, status, backend, perf, history_state, history_view],
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- show training metrics in the Gradio interface so users can verify the model was trained
- measure and display generation latency and maintain input/output history for correctness
- document new UI features

## Testing
- `pip install lxml==5.2.2`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897a6b02390832c899855f34bed9a10