### PR TITLE
feat: support bulk XML generation

### DIFF
--- a/ChatToXml/batch_generate.py
+++ b/ChatToXml/batch_generate.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import List
+
+from config import SCHEMA_DIR
+from repair import repair_to_schema
+from xml_utils import pretty, validate_xml
+
+
+def _parse_quantity(text: str) -> int:
+    """Extract the first integer from *text*.
+
+    If no number is found a quantity of ``1`` is assumed.
+    """
+    match = re.search(r"\b(\d+)\b", text)
+    return int(match.group(1)) if match else 1
+
+
+def _generate_single(prompt: str, schema: str) -> str:
+    """Generate a single XML document from ``prompt`` for ``schema``.
+
+    The function relies on :func:`repair_to_schema` which uses lightweight
+    heuristics to build a valid XML snippet.  The resulting XML is validated
+    against the schema and pretty formatted before returning.
+    """
+    xml = repair_to_schema(prompt, schema)
+    schema_path = SCHEMA_DIR / f"{schema}.xsd"
+    valid, err = validate_xml(xml, str(schema_path))
+    if not valid:
+        raise ValueError(f"Generated XML failed validation: {err}")
+    return pretty(xml)
+
+
+def generate_xml_files(prompt: str, schema: str, output_dir: Path) -> List[Path]:
+    """Generate one or more XML files based on ``prompt``.
+
+    Parameters
+    ----------
+    prompt:
+        Natural language description of the desired XML content.  If the text
+        contains a number (e.g. ``"make 3 users"``) that quantity of files will
+        be produced.
+    schema:
+        Name of the XML schema to validate against (e.g. ``"user"``).
+    output_dir:
+        Directory where generated files are written.  It will be created if it
+        does not already exist.
+
+    Returns
+    -------
+    ``List[Path]``
+        Paths to all generated files, in creation order.
+    """
+    count = _parse_quantity(prompt)
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    generated: List[Path] = []
+    for idx in range(1, count + 1):
+        xml = _generate_single(prompt, schema)
+        file_path = output_dir / f"{schema}_{idx}.xml"
+        file_path.write_text(xml)
+        generated.append(file_path)
+    return generated

--- a/ChatToXml/generate_with_fallback.py
+++ b/ChatToXml/generate_with_fallback.py
@@ -1,7 +1,9 @@
 import argparse
+from pathlib import Path
 
 from transformers import T5ForConditionalGeneration, T5Tokenizer
 
+from batch_generate import generate_xml_files
 from config import MODEL_DIR, SCHEMA_DIR
 from repair import repair_to_schema
 from xml_utils import pretty, validate_xml
@@ -11,7 +13,19 @@ def main() -> None:
     ap = argparse.ArgumentParser()
     ap.add_argument("--prompt", required=True)
     ap.add_argument("--schema", choices=["user", "product", "order"], required=True)
+    ap.add_argument(
+        "--output-dir",
+        type=Path,
+        help="Directory to write XML files. If provided, any quantity in the prompt "
+        "will be used to generate multiple files.",
+    )
     args = ap.parse_args()
+
+    if args.output_dir:
+        paths = generate_xml_files(args.prompt, args.schema, args.output_dir)
+        for p in paths:
+            print(p)
+        return
 
     tokenizer = T5Tokenizer.from_pretrained(MODEL_DIR)
     model = T5ForConditionalGeneration.from_pretrained(MODEL_DIR)

--- a/ChatToXml/src/batch_generate.py
+++ b/ChatToXml/src/batch_generate.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import List
+
+from config import SCHEMA_DIR
+from repair import repair_to_schema
+from xml_utils import pretty, validate_xml
+
+
+def _parse_quantity(text: str) -> int:
+    """Extract the first integer from *text*.
+
+    If no number is found a quantity of ``1`` is assumed.
+    """
+    match = re.search(r"\b(\d+)\b", text)
+    return int(match.group(1)) if match else 1
+
+
+def _generate_single(prompt: str, schema: str) -> str:
+    """Generate a single XML document from ``prompt`` for ``schema``.
+
+    The function relies on :func:`repair_to_schema` which uses lightweight
+    heuristics to build a valid XML snippet.  The resulting XML is validated
+    against the schema and pretty formatted before returning.
+    """
+    xml = repair_to_schema(prompt, schema)
+    schema_path = SCHEMA_DIR / f"{schema}.xsd"
+    valid, err = validate_xml(xml, str(schema_path))
+    if not valid:
+        raise ValueError(f"Generated XML failed validation: {err}")
+    return pretty(xml)
+
+
+def generate_xml_files(prompt: str, schema: str, output_dir: Path) -> List[Path]:
+    """Generate one or more XML files based on ``prompt``.
+
+    Parameters
+    ----------
+    prompt:
+        Natural language description of the desired XML content.  If the text
+        contains a number (e.g. ``"make 3 users"``) that quantity of files will
+        be produced.
+    schema:
+        Name of the XML schema to validate against (e.g. ``"user"``).
+    output_dir:
+        Directory where generated files are written.  It will be created if it
+        does not already exist.
+
+    Returns
+    -------
+    ``List[Path]``
+        Paths to all generated files, in creation order.
+    """
+    count = _parse_quantity(prompt)
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    generated: List[Path] = []
+    for idx in range(1, count + 1):
+        xml = _generate_single(prompt, schema)
+        file_path = output_dir / f"{schema}_{idx}.xml"
+        file_path.write_text(xml)
+        generated.append(file_path)
+    return generated

--- a/ChatToXml/src/generate_with_fallback.py
+++ b/ChatToXml/src/generate_with_fallback.py
@@ -1,7 +1,9 @@
 import argparse
+from pathlib import Path
 
 from transformers import T5ForConditionalGeneration, T5Tokenizer
 
+from batch_generate import generate_xml_files
 from config import MODEL_DIR, SCHEMA_DIR
 from repair import repair_to_schema
 from xml_utils import pretty, validate_xml
@@ -11,7 +13,19 @@ def main() -> None:
     ap = argparse.ArgumentParser()
     ap.add_argument("--prompt", required=True)
     ap.add_argument("--schema", choices=["user", "product", "order"], required=True)
+    ap.add_argument(
+        "--output-dir",
+        type=Path,
+        help="Directory to write XML files. If provided, any quantity in the prompt "
+        "will be used to generate multiple files.",
+    )
     args = ap.parse_args()
+
+    if args.output_dir:
+        paths = generate_xml_files(args.prompt, args.schema, args.output_dir)
+        for p in paths:
+            print(p)
+        return
 
     tokenizer = T5Tokenizer.from_pretrained(MODEL_DIR)
     model = T5ForConditionalGeneration.from_pretrained(MODEL_DIR)

--- a/ChatToXml/tests/test_batch_generate.py
+++ b/ChatToXml/tests/test_batch_generate.py
@@ -1,0 +1,22 @@
+import sys
+from pathlib import Path
+
+# Ensure src is on the Python path
+sys.path.append(str(Path(__file__).resolve().parents[1] / 'src'))
+
+import config
+from batch_generate import generate_xml_files
+from xml_utils import validate_xml
+
+
+def test_generate_multiple_files(tmp_path):
+    prompt = "make 3 users named Adam. There are 3 users named Adam"
+    paths = generate_xml_files(prompt, "user", tmp_path)
+    assert len(paths) == 3
+    for idx, p in enumerate(paths, 1):
+        assert p.name == f"user_{idx}.xml"
+        xml_content = p.read_text()
+        schema_path = config.SCHEMA_DIR / 'user.xsd'
+        valid, error = validate_xml(xml_content, str(schema_path))
+        assert valid, error
+        assert "<name>Adam</name>" in xml_content


### PR DESCRIPTION
## Summary
- add `generate_xml_files` utility to produce multiple XML files from prompts
- extend `generate_with_fallback.py` with `--output-dir` for bulk generation
- test multi-file creation and schema validation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e89b7f608832c9cb480697696569d