### PR TITLE
Allow custom values in synthetic data generator

### DIFF
--- a/ChatToXml/README.md
+++ b/ChatToXml/README.md
@@ -50,9 +50,19 @@ The repository includes `src/synth_data.py`, which produces a synthetic dataset 
 python src/synth_data.py
 ```
 
-This writes `data/sample_data.csv`. To customize the dataset, modify the
-generators in `synth_data.py` or replace the CSV with your own examples following
-the same schema.
+This writes `data/sample_data.csv`. The generator accepts optional pools of
+names, product titles, and currency codes as well as a random seed:
+
+```python
+from synth_data import generate_dataset
+
+generate_dataset(
+    names=["Ada"], products=["Widget"], currencies=["GBP"], seed=0
+)
+```
+
+For more extensive changes, modify the generators in `synth_data.py` or replace
+the CSV with your own examples following the same schema.
 
 ## Training the Model
 

--- a/ChatToXml/src/synth_data.py
+++ b/ChatToXml/src/synth_data.py
@@ -1,6 +1,8 @@
 import csv
-import random
+from dataclasses import dataclass, field
+from random import Random
 from pathlib import Path
+from typing import Callable, List, Sequence, Tuple
 
 # Default location for the generated dataset
 OUT = Path(__file__).resolve().parents[1] / "data" / "sample_data.csv"
@@ -29,85 +31,120 @@ PRODUCTS = [
     "Quantum Cup",
     "ThermoPad",
 ]
-CURRENCIES = ["USD", "EUR", "JPY"]
+DEFAULT_CURRENCIES = ["USD", "EUR", "JPY"]
 
 
-def user_example() -> tuple[str, str]:
-    name = random.choice(NAMES)
-    if random.random() < 0.6:
-        name += f" {random.choice(NAMES)}"
-    uid = str(random.randint(100, 9999))
-    email = f"{name.split()[0].lower()}@example.com" if random.random() < 0.7 else None
-    nl = random.choice(
-        [
-            f"Create a user named {name} with ID {uid}",
-            f"Register user {name}, id {uid}",
-            f"Add a new user: name={name}, id={uid}",
-            f"Set up user {name} ({uid})",
-        ]
-    )
-    xml = f"<user><id>{uid}</id><name>{name}</name>"
-    if email:
-        xml += f"<email>{email}</email>"
-    xml += "</user>"
-    return nl, xml
+@dataclass
+class SyntheticDataGenerator:
+    """Generate synthetic natural-language/XML pairs.
+
+    The generator can be configured with custom value pools. A dedicated
+    :class:`random.Random` instance is used so callers may supply a seed for
+    deterministic outputs.
+    """
+
+    names: Sequence[str] = field(default_factory=lambda: NAMES)
+    products: Sequence[str] = field(default_factory=lambda: PRODUCTS)
+    currencies: Sequence[str] = field(default_factory=lambda: DEFAULT_CURRENCIES)
+    rng: Random = field(default_factory=Random)
+
+    def user_example(self) -> Tuple[str, str]:
+        name = self.rng.choice(self.names)
+        if self.rng.random() < 0.6:
+            name += f" {self.rng.choice(self.names)}"
+        uid = str(self.rng.randint(100, 9999))
+        email = f"{name.split()[0].lower()}@example.com" if self.rng.random() < 0.7 else None
+        nl = self.rng.choice(
+            [
+                f"Create a user named {name} with ID {uid}",
+                f"Register user {name}, id {uid}",
+                f"Add a new user: name={name}, id={uid}",
+                f"Set up user {name} ({uid})",
+            ]
+        )
+        xml = f"<user><id>{uid}</id><name>{name}</name>"
+        if email:
+            xml += f"<email>{email}</email>"
+        xml += "</user>"
+        return nl, xml
+
+    def product_example(self) -> Tuple[str, str]:
+        name = self.rng.choice(self.products)
+        sku = f"SKU-{self.rng.randint(1000, 9999)}"
+        price = f"{self.rng.randint(1, 999)}.{self.rng.randint(0, 99):02d}"
+        cur = self.rng.choice(self.currencies)
+        nl = self.rng.choice(
+            [
+                f"Add a product called {name} priced at {price} {cur} with sku {sku}",
+                f"Register product {name}; price {price} {cur}; SKU {sku}",
+                f"Create product {name} (sku {sku}) costing {price} {cur}",
+            ]
+        )
+        xml = (
+            f"<product><sku>{sku}</sku><name>{name}</name>"
+            f"<price>{price}</price><currency>{cur}</currency></product>"
+        )
+        return nl, xml
+
+    def order_example(self) -> Tuple[str, str]:
+        oid = str(self.rng.randint(100, 99999))
+        user = self.rng.choice(self.names)
+        total = f"{self.rng.randint(10, 4999)}.{self.rng.randint(0, 99):02d}"
+        nl = self.rng.choice(
+            [
+                f"Create an order {oid} for user {user} totaling {total}",
+                f"Add order id {oid} belonging to {user}, total {total}",
+                f"Register order {oid} for {user} with total {total}",
+            ]
+        )
+        xml = f"<order><id>{oid}</id><user>{user}</user><total>{total}</total></order>"
+        return nl, xml
+
+    @property
+    def generators(self) -> List[Callable[[], Tuple[str, str]]]:
+        return [self.user_example, self.product_example, self.order_example]
+
+    def generate_dataset(self, n: int = N, out_path: Path = OUT) -> Path:
+        with out_path.open("w", newline="", encoding="utf-8") as f:
+            writer = csv.writer(f)
+            writer.writerow(["input", "text_output"])
+            for _ in range(n):
+                nl, xml = self.rng.choice(self.generators)()
+                writer.writerow([nl, xml])
+        return out_path
 
 
-def product_example() -> tuple[str, str]:
-    name = random.choice(PRODUCTS)
-    sku = f"SKU-{random.randint(1000, 9999)}"
-    price = f"{random.randint(1, 999)}.{random.randint(0, 99):02d}"
-    cur = random.choice(CURRENCIES)
-    nl = random.choice(
-        [
-            f"Add a product called {name} priced at {price} {cur} with sku {sku}",
-            f"Register product {name}; price {price} {cur}; SKU {sku}",
-            f"Create product {name} (sku {sku}) costing {price} {cur}",
-        ]
-    )
-    xml = (
-        f"<product><sku>{sku}</sku><name>{name}</name>"
-        f"<price>{price}</price><currency>{cur}</currency></product>"
-    )
-    return nl, xml
-
-
-def order_example() -> tuple[str, str]:
-    oid = str(random.randint(100, 99999))
-    user = random.choice(NAMES)
-    total = f"{random.randint(10, 4999)}.{random.randint(0, 99):02d}"
-    nl = random.choice(
-        [
-            f"Create an order {oid} for user {user} totaling {total}",
-            f"Add order id {oid} belonging to {user}, total {total}",
-            f"Register order {oid} for {user} with total {total}",
-        ]
-    )
-    xml = f"<order><id>{oid}</id><user>{user}</user><total>{total}</total></order>"
-    return nl, xml
-
-
-GENERATORS = [user_example, product_example, order_example]
-
-
-def generate_dataset(n: int = N, out_path: Path = OUT) -> Path:
+def generate_dataset(
+    n: int = N,
+    out_path: Path = OUT,
+    *,
+    names: Sequence[str] | None = None,
+    products: Sequence[str] | None = None,
+    currencies: Sequence[str] | None = None,
+    seed: int | None = None,
+) -> Path:
     """Generate a synthetic dataset and write it to ``out_path``.
 
     Args:
         n: Number of records to create.
         out_path: Destination path for the CSV file.
+        names: Optional pool of user names.
+        products: Optional pool of product names.
+        currencies: Optional pool of currency codes.
+        seed: Optional seed for deterministic output.
 
     Returns:
         Path to the generated CSV file.
     """
-    with out_path.open("w", newline="", encoding="utf-8") as f:
-        writer = csv.writer(f)
-        writer.writerow(["input", "text_output"])
-        for _ in range(n):
-            nl, xml = random.choice(GENERATORS)()
-            writer.writerow([nl, xml])
-    return out_path
+    gen = SyntheticDataGenerator(
+        names=names or NAMES,
+        products=products or PRODUCTS,
+        currencies=currencies or DEFAULT_CURRENCIES,
+        rng=Random(seed),
+    )
+    return gen.generate_dataset(n, out_path)
 
 
 if __name__ == "__main__":
     generate_dataset()
+

--- a/ChatToXml/synth_data.py
+++ b/ChatToXml/synth_data.py
@@ -1,6 +1,8 @@
 import csv
-import random
+from dataclasses import dataclass, field
+from random import Random
 from pathlib import Path
+from typing import Callable, List, Sequence, Tuple
 
 # Default location for the generated dataset
 OUT = Path(__file__).resolve().parents[1] / "data" / "sample_data.csv"
@@ -29,85 +31,120 @@ PRODUCTS = [
     "Quantum Cup",
     "ThermoPad",
 ]
-CURRENCIES = ["USD", "EUR", "JPY"]
+DEFAULT_CURRENCIES = ["USD", "EUR", "JPY"]
 
 
-def user_example() -> tuple[str, str]:
-    name = random.choice(NAMES)
-    if random.random() < 0.6:
-        name += f" {random.choice(NAMES)}"
-    uid = str(random.randint(100, 9999))
-    email = f"{name.split()[0].lower()}@example.com" if random.random() < 0.7 else None
-    nl = random.choice(
-        [
-            f"Create a user named {name} with ID {uid}",
-            f"Register user {name}, id {uid}",
-            f"Add a new user: name={name}, id={uid}",
-            f"Set up user {name} ({uid})",
-        ]
-    )
-    xml = f"<user><id>{uid}</id><name>{name}</name>"
-    if email:
-        xml += f"<email>{email}</email>"
-    xml += "</user>"
-    return nl, xml
+@dataclass
+class SyntheticDataGenerator:
+    """Generate synthetic natural-language/XML pairs.
+
+    The generator can be configured with custom value pools. A dedicated
+    :class:`random.Random` instance is used so callers may supply a seed for
+    deterministic outputs.
+    """
+
+    names: Sequence[str] = field(default_factory=lambda: NAMES)
+    products: Sequence[str] = field(default_factory=lambda: PRODUCTS)
+    currencies: Sequence[str] = field(default_factory=lambda: DEFAULT_CURRENCIES)
+    rng: Random = field(default_factory=Random)
+
+    def user_example(self) -> Tuple[str, str]:
+        name = self.rng.choice(self.names)
+        if self.rng.random() < 0.6:
+            name += f" {self.rng.choice(self.names)}"
+        uid = str(self.rng.randint(100, 9999))
+        email = f"{name.split()[0].lower()}@example.com" if self.rng.random() < 0.7 else None
+        nl = self.rng.choice(
+            [
+                f"Create a user named {name} with ID {uid}",
+                f"Register user {name}, id {uid}",
+                f"Add a new user: name={name}, id={uid}",
+                f"Set up user {name} ({uid})",
+            ]
+        )
+        xml = f"<user><id>{uid}</id><name>{name}</name>"
+        if email:
+            xml += f"<email>{email}</email>"
+        xml += "</user>"
+        return nl, xml
+
+    def product_example(self) -> Tuple[str, str]:
+        name = self.rng.choice(self.products)
+        sku = f"SKU-{self.rng.randint(1000, 9999)}"
+        price = f"{self.rng.randint(1, 999)}.{self.rng.randint(0, 99):02d}"
+        cur = self.rng.choice(self.currencies)
+        nl = self.rng.choice(
+            [
+                f"Add a product called {name} priced at {price} {cur} with sku {sku}",
+                f"Register product {name}; price {price} {cur}; SKU {sku}",
+                f"Create product {name} (sku {sku}) costing {price} {cur}",
+            ]
+        )
+        xml = (
+            f"<product><sku>{sku}</sku><name>{name}</name>"
+            f"<price>{price}</price><currency>{cur}</currency></product>"
+        )
+        return nl, xml
+
+    def order_example(self) -> Tuple[str, str]:
+        oid = str(self.rng.randint(100, 99999))
+        user = self.rng.choice(self.names)
+        total = f"{self.rng.randint(10, 4999)}.{self.rng.randint(0, 99):02d}"
+        nl = self.rng.choice(
+            [
+                f"Create an order {oid} for user {user} totaling {total}",
+                f"Add order id {oid} belonging to {user}, total {total}",
+                f"Register order {oid} for {user} with total {total}",
+            ]
+        )
+        xml = f"<order><id>{oid}</id><user>{user}</user><total>{total}</total></order>"
+        return nl, xml
+
+    @property
+    def generators(self) -> List[Callable[[], Tuple[str, str]]]:
+        return [self.user_example, self.product_example, self.order_example]
+
+    def generate_dataset(self, n: int = N, out_path: Path = OUT) -> Path:
+        with out_path.open("w", newline="", encoding="utf-8") as f:
+            writer = csv.writer(f)
+            writer.writerow(["input", "text_output"])
+            for _ in range(n):
+                nl, xml = self.rng.choice(self.generators)()
+                writer.writerow([nl, xml])
+        return out_path
 
 
-def product_example() -> tuple[str, str]:
-    name = random.choice(PRODUCTS)
-    sku = f"SKU-{random.randint(1000, 9999)}"
-    price = f"{random.randint(1, 999)}.{random.randint(0, 99):02d}"
-    cur = random.choice(CURRENCIES)
-    nl = random.choice(
-        [
-            f"Add a product called {name} priced at {price} {cur} with sku {sku}",
-            f"Register product {name}; price {price} {cur}; SKU {sku}",
-            f"Create product {name} (sku {sku}) costing {price} {cur}",
-        ]
-    )
-    xml = (
-        f"<product><sku>{sku}</sku><name>{name}</name>"
-        f"<price>{price}</price><currency>{cur}</currency></product>"
-    )
-    return nl, xml
-
-
-def order_example() -> tuple[str, str]:
-    oid = str(random.randint(100, 99999))
-    user = random.choice(NAMES)
-    total = f"{random.randint(10, 4999)}.{random.randint(0, 99):02d}"
-    nl = random.choice(
-        [
-            f"Create an order {oid} for user {user} totaling {total}",
-            f"Add order id {oid} belonging to {user}, total {total}",
-            f"Register order {oid} for {user} with total {total}",
-        ]
-    )
-    xml = f"<order><id>{oid}</id><user>{user}</user><total>{total}</total></order>"
-    return nl, xml
-
-
-GENERATORS = [user_example, product_example, order_example]
-
-
-def generate_dataset(n: int = N, out_path: Path = OUT) -> Path:
+def generate_dataset(
+    n: int = N,
+    out_path: Path = OUT,
+    *,
+    names: Sequence[str] | None = None,
+    products: Sequence[str] | None = None,
+    currencies: Sequence[str] | None = None,
+    seed: int | None = None,
+) -> Path:
     """Generate a synthetic dataset and write it to ``out_path``.
 
     Args:
         n: Number of records to create.
         out_path: Destination path for the CSV file.
+        names: Optional pool of user names.
+        products: Optional pool of product names.
+        currencies: Optional pool of currency codes.
+        seed: Optional seed for deterministic output.
 
     Returns:
         Path to the generated CSV file.
     """
-    with out_path.open("w", newline="", encoding="utf-8") as f:
-        writer = csv.writer(f)
-        writer.writerow(["input", "text_output"])
-        for _ in range(n):
-            nl, xml = random.choice(GENERATORS)()
-            writer.writerow([nl, xml])
-    return out_path
+    gen = SyntheticDataGenerator(
+        names=names or NAMES,
+        products=products or PRODUCTS,
+        currencies=currencies or DEFAULT_CURRENCIES,
+        rng=Random(seed),
+    )
+    return gen.generate_dataset(n, out_path)
 
 
 if __name__ == "__main__":
     generate_dataset()
+

--- a/ChatToXml/tests/test_synth_data.py
+++ b/ChatToXml/tests/test_synth_data.py
@@ -1,0 +1,30 @@
+import csv
+import sys
+from pathlib import Path
+
+# Ensure src is on the Python path
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from synth_data import generate_dataset
+
+
+def test_generate_dataset_with_custom_values(tmp_path):
+    out_file = tmp_path / "data.csv"
+    generate_dataset(
+        n=10,
+        out_path=out_file,
+        names=["Xavier"],
+        products=["MegaWidget"],
+        currencies=["GBP"],
+        seed=0,
+    )
+
+    with out_file.open() as f:
+        rows = list(csv.DictReader(f))
+
+    assert len(rows) == 10
+    text = " ".join(r["input"] + r["text_output"] for r in rows)
+    assert "Xavier" in text
+    assert "MegaWidget" in text
+    assert "GBP" in text
+


### PR DESCRIPTION
## Summary
- refactor synthetic data generation to use `SyntheticDataGenerator` class
- support user-supplied names, products, currencies and deterministic seed
- document and test the customization capability

## Testing
- `pytest ChatToXml/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_689eb307ddac832ca42c6731738f3202