### PR TITLE
feat: add file CRUD controls to UI

### DIFF
--- a/ChatToXml/file_store.py
+++ b/ChatToXml/file_store.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+
+# Directory for persisting generated XML files
+OUTPUT_DIR = Path("data") / "outputs"
+OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _safe_path(name: str) -> Path:
+    """Return a safe file path within OUTPUT_DIR for the given name."""
+    return OUTPUT_DIR / Path(name).name
+
+
+def create_xml_file(file_name: str, xml_content: str) -> str:
+    """Create a new XML file with the provided content."""
+    path = _safe_path(file_name)
+    if path.exists():
+        return f"File {path} already exists."
+    path.write_text(xml_content, encoding="utf-8")
+    return f"Created {path}"
+
+
+def read_xml_file(file_name: str) -> tuple[str, str]:
+    """Read an XML file and return its contents and status message."""
+    path = _safe_path(file_name)
+    if not path.exists():
+        return "", f"File {path} does not exist."
+    content = path.read_text(encoding="utf-8")
+    return content, f"Loaded {path}"
+
+
+def update_xml_file(file_name: str, xml_content: str) -> str:
+    """Update an existing XML file with new content."""
+    path = _safe_path(file_name)
+    if not path.exists():
+        return f"File {path} does not exist."
+    path.write_text(xml_content, encoding="utf-8")
+    return f"Updated {path}"
+
+
+def delete_xml_file(file_name: str) -> str:
+    """Delete an XML file."""
+    path = _safe_path(file_name)
+    if not path.exists():
+        return f"File {path} does not exist."
+    path.unlink()
+    return f"Deleted {path}"

--- a/ChatToXml/tests/test_file_store.py
+++ b/ChatToXml/tests/test_file_store.py
@@ -1,0 +1,36 @@
+import sys
+from pathlib import Path
+
+# Add project root to sys.path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import file_store
+
+
+def test_crud_lifecycle(monkeypatch, tmp_path):
+    # Redirect output directory to a temporary path
+    monkeypatch.setattr(file_store, "OUTPUT_DIR", tmp_path)
+
+    status = file_store.create_xml_file("sample.xml", "<root/>")
+    assert "Created" in status
+    assert (tmp_path / "sample.xml").exists()
+
+    content, msg = file_store.read_xml_file("sample.xml")
+    assert content == "<root/>"
+    assert "Loaded" in msg
+
+    update_status = file_store.update_xml_file("sample.xml", "<root>updated</root>")
+    assert "Updated" in update_status
+    updated_content, _ = file_store.read_xml_file("sample.xml")
+    assert updated_content == "<root>updated</root>"
+
+    delete_status = file_store.delete_xml_file("sample.xml")
+    assert "Deleted" in delete_status
+    assert not (tmp_path / "sample.xml").exists()
+
+
+def test_safe_path(monkeypatch, tmp_path):
+    monkeypatch.setattr(file_store, "OUTPUT_DIR", tmp_path)
+    file_store.create_xml_file("../evil.xml", "<root/>")
+    # Path traversal should be sanitized
+    assert (tmp_path / "evil.xml").exists()

--- a/ChatToXml/ui.py
+++ b/ChatToXml/ui.py
@@ -12,6 +12,12 @@ from config import MODEL_DIR, SCHEMA_DIR
 from xml_utils import pretty, validate_xml
 from synth_data import generate_dataset
 from train import main as train_main
+from file_store import (
+    create_xml_file,
+    read_xml_file,
+    update_xml_file,
+    delete_xml_file,
+)
 
 ONNX_DIR = Path(MODEL_DIR).parent / "onnx"
 
@@ -167,7 +173,17 @@ with gr.Blocks(title="Offline XML Generator") as app:
             inputs=[prompt, schema],
             label="Example Prompts",
         )
-        xml_out = gr.Code(label="Generated XML", language="html")
+        with gr.Row():
+            xml_out = gr.Code(label="Generated XML", language="html")
+            with gr.Column():
+                file_name = gr.Textbox(label="File Name", value="output.xml")
+                with gr.Row():
+                    create_btn = gr.Button("Create")
+                    read_btn = gr.Button("Read")
+                with gr.Row():
+                    update_btn = gr.Button("Update")
+                    delete_btn = gr.Button("Delete")
+                file_status = gr.Markdown()
         status = gr.Markdown()
         backend = gr.Markdown()
         perf = gr.Markdown()
@@ -177,6 +193,18 @@ with gr.Blocks(title="Offline XML Generator") as app:
             fn=generate_and_validate,
             inputs=[prompt, schema, auto_repair, history_state],
             outputs=[xml_out, status, backend, perf, history_state, history_view],
+        )
+        create_btn.click(
+            fn=create_xml_file, inputs=[file_name, xml_out], outputs=file_status
+        )
+        read_btn.click(
+            fn=read_xml_file, inputs=[file_name], outputs=[xml_out, file_status]
+        )
+        update_btn.click(
+            fn=update_xml_file, inputs=[file_name, xml_out], outputs=file_status
+        )
+        delete_btn.click(
+            fn=delete_xml_file, inputs=[file_name], outputs=file_status
         )
 
     with gr.Column(visible=False) as training_panel:


### PR DESCRIPTION
## Summary
- persist generated XML to `data/outputs` with create/read/update/delete helpers
- add UI controls to manage XML files alongside generated output
- test file persistence helpers for lifecycle and path safety

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689fd622a0e4832cb038f822f1efefc4