### PR TITLE
feat: add zip file management to UI

### DIFF
--- a/ChatToXml/file_store.py
+++ b/ChatToXml/file_store.py
@@ -1,6 +1,8 @@
 from pathlib import Path
+import shutil
+from zipfile import ZipFile
 
-# Directory for persisting generated XML files
+# Directory for persisting generated files
 OUTPUT_DIR = Path("data") / "outputs"
 OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
 
@@ -10,37 +12,48 @@ def _safe_path(name: str) -> Path:
     return OUTPUT_DIR / Path(name).name
 
 
-def create_xml_file(file_name: str, xml_content: str) -> str:
-    """Create a new XML file with the provided content."""
+def create_zip_file(file_name: str, source_zip: str) -> str:
+    """Persist an uploaded ZIP archive to the output directory."""
     path = _safe_path(file_name)
     if path.exists():
         return f"File {path} already exists."
-    path.write_text(xml_content, encoding="utf-8")
+    shutil.copy(Path(source_zip), path)
     return f"Created {path}"
 
 
-def read_xml_file(file_name: str) -> tuple[str, str]:
-    """Read an XML file and return its contents and status message."""
+def read_zip_file(file_name: str) -> tuple[str, str]:
+    """Read a ZIP archive and return a newline separated listing of its contents."""
     path = _safe_path(file_name)
     if not path.exists():
         return "", f"File {path} does not exist."
-    content = path.read_text(encoding="utf-8")
-    return content, f"Loaded {path}"
+    with ZipFile(path) as zf:
+        listing = "\n".join(zf.namelist())
+    return listing, f"Loaded {path}"
 
 
-def update_xml_file(file_name: str, xml_content: str) -> str:
-    """Update an existing XML file with new content."""
+def update_zip_file(file_name: str, source_zip: str) -> str:
+    """Replace the contents of an existing ZIP archive."""
     path = _safe_path(file_name)
     if not path.exists():
         return f"File {path} does not exist."
-    path.write_text(xml_content, encoding="utf-8")
+    shutil.copy(Path(source_zip), path)
     return f"Updated {path}"
 
 
-def delete_xml_file(file_name: str) -> str:
-    """Delete an XML file."""
+def delete_zip_file(file_name: str) -> str:
+    """Delete a ZIP archive."""
     path = _safe_path(file_name)
     if not path.exists():
         return f"File {path} does not exist."
     path.unlink()
     return f"Deleted {path}"
+
+
+def extract_zip_file(source_zip: str) -> str:
+    """Extract the given ZIP archive into OUTPUT_DIR."""
+    path = Path(source_zip)
+    if not path.exists():
+        return f"File {path} does not exist."
+    with ZipFile(path) as zf:
+        zf.extractall(OUTPUT_DIR)
+    return f"Extracted {path} to {OUTPUT_DIR}"

--- a/ChatToXml/tests/test_file_store.py
+++ b/ChatToXml/tests/test_file_store.py
@@ -1,5 +1,6 @@
 import sys
 from pathlib import Path
+from zipfile import ZipFile
 
 # Add project root to sys.path
 sys.path.append(str(Path(__file__).resolve().parents[1]))
@@ -7,30 +8,47 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 import file_store
 
 
-def test_crud_lifecycle(monkeypatch, tmp_path):
+def _make_zip(tmp_path: Path, name: str) -> Path:
+    """Create a zip file containing three XML files in separate folders."""
+    for i in range(3):
+        folder = tmp_path / f"folder{i}"
+        folder.mkdir(parents=True, exist_ok=True)
+        (folder / f"file{i}.xml").write_text(f"<root{i}/>")
+    zip_path = tmp_path / name
+    with ZipFile(zip_path, "w") as zf:
+        for i in range(3):
+            folder = tmp_path / f"folder{i}"
+            for file in folder.iterdir():
+                zf.write(file, arcname=f"{folder.name}/{file.name}")
+    return zip_path
+
+
+def test_zip_crud_lifecycle(monkeypatch, tmp_path):
     # Redirect output directory to a temporary path
     monkeypatch.setattr(file_store, "OUTPUT_DIR", tmp_path)
 
-    status = file_store.create_xml_file("sample.xml", "<root/>")
+    src_zip = _make_zip(tmp_path, "src.zip")
+    status = file_store.create_zip_file("archive.zip", str(src_zip))
     assert "Created" in status
-    assert (tmp_path / "sample.xml").exists()
+    assert (tmp_path / "archive.zip").exists()
 
-    content, msg = file_store.read_xml_file("sample.xml")
-    assert content == "<root/>"
+    listing, msg = file_store.read_zip_file("archive.zip")
+    assert "folder0/file0.xml" in listing
     assert "Loaded" in msg
 
-    update_status = file_store.update_xml_file("sample.xml", "<root>updated</root>")
+    # Create another zip to update
+    src_zip2 = _make_zip(tmp_path, "src2.zip")
+    update_status = file_store.update_zip_file("archive.zip", str(src_zip2))
     assert "Updated" in update_status
-    updated_content, _ = file_store.read_xml_file("sample.xml")
-    assert updated_content == "<root>updated</root>"
 
-    delete_status = file_store.delete_xml_file("sample.xml")
+    delete_status = file_store.delete_zip_file("archive.zip")
     assert "Deleted" in delete_status
-    assert not (tmp_path / "sample.xml").exists()
+    assert not (tmp_path / "archive.zip").exists()
 
 
 def test_safe_path(monkeypatch, tmp_path):
     monkeypatch.setattr(file_store, "OUTPUT_DIR", tmp_path)
-    file_store.create_xml_file("../evil.xml", "<root/>")
+    src_zip = _make_zip(tmp_path, "src.zip")
+    file_store.create_zip_file("../evil.zip", str(src_zip))
     # Path traversal should be sanitized
-    assert (tmp_path / "evil.xml").exists()
+    assert (tmp_path / "evil.zip").exists()

--- a/ChatToXml/ui.py
+++ b/ChatToXml/ui.py
@@ -13,10 +13,11 @@ from xml_utils import pretty, validate_xml
 from synth_data import generate_dataset
 from train import main as train_main
 from file_store import (
-    create_xml_file,
-    read_xml_file,
-    update_xml_file,
-    delete_xml_file,
+    create_zip_file,
+    read_zip_file,
+    update_zip_file,
+    delete_zip_file,
+    extract_zip_file,
 )
 
 ONNX_DIR = Path(MODEL_DIR).parent / "onnx"
@@ -176,7 +177,10 @@ with gr.Blocks(title="Offline XML Generator") as app:
         with gr.Row():
             xml_out = gr.Code(label="Generated XML", language="html")
             with gr.Column():
-                file_name = gr.Textbox(label="File Name", value="output.xml")
+                zip_file = gr.File(label="ZIP File", file_types=[".zip"], type="filepath")
+                unzip_btn = gr.Button("Unzip")
+                unzip_status = gr.Markdown()
+                file_name = gr.Textbox(label="Zip Name", value="archive.zip")
                 with gr.Row():
                     create_btn = gr.Button("Create")
                     read_btn = gr.Button("Read")
@@ -195,16 +199,19 @@ with gr.Blocks(title="Offline XML Generator") as app:
             outputs=[xml_out, status, backend, perf, history_state, history_view],
         )
         create_btn.click(
-            fn=create_xml_file, inputs=[file_name, xml_out], outputs=file_status
+            fn=create_zip_file, inputs=[file_name, zip_file], outputs=file_status
         )
         read_btn.click(
-            fn=read_xml_file, inputs=[file_name], outputs=[xml_out, file_status]
+            fn=read_zip_file, inputs=[file_name], outputs=[xml_out, file_status]
         )
         update_btn.click(
-            fn=update_xml_file, inputs=[file_name, xml_out], outputs=file_status
+            fn=update_zip_file, inputs=[file_name, zip_file], outputs=file_status
         )
         delete_btn.click(
-            fn=delete_xml_file, inputs=[file_name], outputs=file_status
+            fn=delete_zip_file, inputs=[file_name], outputs=file_status
+        )
+        unzip_btn.click(
+            fn=extract_zip_file, inputs=[zip_file], outputs=unzip_status
         )
 
     with gr.Column(visible=False) as training_panel:


### PR DESCRIPTION
## Summary
- support CRUD operations on zip archives
- allow users to upload and unzip archives via the UI
- test zip archive workflows and path safety

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689fdf0d370c832ca7357b006ab01e16