### PR TITLE
Add Plotly validation metrics

### DIFF
--- a/ChatToXml/requirements.txt
+++ b/ChatToXml/requirements.txt
@@ -6,3 +6,4 @@ evaluate==0.4.2
 optimum==1.20.0
 onnxruntime==1.18.0
 gradio==4.44.0
+plotly==5.22.0

--- a/ChatToXml/src/ui.py
+++ b/ChatToXml/src/ui.py
@@ -1,11 +1,12 @@
 import json
 import time
 from typing import List
+from pathlib import Path
 
 import gradio as gr
-from pathlib import Path
 from optimum.onnxruntime import ORTModelForSeq2SeqLM
 from transformers import T5ForConditionalGeneration, T5Tokenizer
+import plotly.graph_objects as go
 
 from config import MODEL_DIR, SCHEMA_DIR
 from xml_utils import pretty, validate_xml
@@ -37,29 +38,58 @@ def _load_backend():
 
 
 
-def _load_training_metrics() -> str:
+def _load_training_metrics() -> tuple[str, go.Figure]:
     trainer_state = Path(MODEL_DIR) / "trainer_state.json"
     if not trainer_state.exists():
-        return "Training metrics not available."
+        return "Training metrics not available.", go.Figure()
     with trainer_state.open() as f:
         state = json.load(f)
-    train_loss = None
-    eval_loss = None
+
+    train_epochs: list[float] = []
+    train_losses: list[float] = []
+    eval_epochs: list[float] = []
+    eval_losses: list[float] = []
+    eval_accs: list[float] = []
+
     for entry in state.get("log_history", []):
-        if "train_loss" in entry:
-            train_loss = entry["train_loss"]
-        if "eval_loss" in entry:
-            eval_loss = entry["eval_loss"]
+        if "loss" in entry and "epoch" in entry:
+            train_epochs.append(entry["epoch"])
+            train_losses.append(entry["loss"])
+        if "eval_loss" in entry and "epoch" in entry:
+            eval_epochs.append(entry["epoch"])
+            eval_losses.append(entry["eval_loss"])
+            if "eval_accuracy" in entry:
+                eval_accs.append(entry["eval_accuracy"])
+
     metrics = []
-    if train_loss is not None:
-        metrics.append(f"train_loss: {train_loss:.4f}")
-    if eval_loss is not None:
-        metrics.append(f"eval_loss: {eval_loss:.4f}")
-    return "Training metrics - " + ", ".join(metrics)
+    if train_losses:
+        metrics.append(f"train_loss: {train_losses[-1]:.4f}")
+    if eval_losses:
+        metrics.append(f"eval_loss: {eval_losses[-1]:.4f}")
+    if eval_accs:
+        metrics.append(f"eval_accuracy: {eval_accs[-1]:.4f}")
+
+    fig = go.Figure()
+    if train_epochs:
+        fig.add_trace(
+            go.Scatter(x=train_epochs, y=train_losses, mode="lines+markers", name="Train Loss")
+        )
+    if eval_epochs:
+        fig.add_trace(
+            go.Scatter(x=eval_epochs, y=eval_losses, mode="lines+markers", name="Validation Loss")
+        )
+    if eval_epochs and eval_accs:
+        fig.add_trace(
+            go.Scatter(x=eval_epochs, y=eval_accs, mode="lines+markers", name="Validation Accuracy", yaxis="y2")
+        )
+        fig.update_layout(yaxis2=dict(title="Accuracy", overlaying="y", side="right"))
+    fig.update_layout(title="Training Metrics", xaxis_title="Epoch", yaxis_title="Loss")
+
+    return "Training metrics - " + ", ".join(metrics), fig
 
 
 MODEL, TOKENIZER, BACKEND = _load_backend()
-TRAINING_INFO = _load_training_metrics()
+TRAINING_INFO, TRAINING_FIG = _load_training_metrics()
 
 
 def generate_and_validate(prompt: str, schema: str, history: List[List[str]]):
@@ -87,12 +117,12 @@ def run_data_generation() -> str:
     return f"Synthetic dataset generated at {path}"
 
 
-def run_training() -> tuple[str, str]:
+def run_training() -> tuple[str, str, go.Figure]:
     train_main()
     global MODEL, TOKENIZER, BACKEND
     MODEL, TOKENIZER, BACKEND = _load_backend()
-    metrics = _load_training_metrics()
-    return "Training complete", metrics
+    metrics, fig = _load_training_metrics()
+    return "Training complete", metrics, fig
 
 
 with gr.Blocks(title="Offline XML Generator") as app:
@@ -136,11 +166,12 @@ with gr.Blocks(title="Offline XML Generator") as app:
 
     with gr.Column(visible=False) as training_panel:
         metrics_md = gr.Markdown(TRAINING_INFO)
+        metrics_plot = gr.Plot(value=TRAINING_FIG)
         gen_btn = gr.Button("Generate Synthetic Data")
         train_btn = gr.Button("Train Model")
         train_status = gr.Markdown()
         gen_btn.click(fn=run_data_generation, outputs=train_status)
-        train_btn.click(fn=run_training, outputs=[train_status, metrics_md])
+        train_btn.click(fn=run_training, outputs=[train_status, metrics_md, metrics_plot])
 
     def _switch_mode(m: str):
         return (gr.update(visible=m == "Validation"), gr.update(visible=m == "Training"))

--- a/ChatToXml/train.py
+++ b/ChatToXml/train.py
@@ -8,9 +8,11 @@ from transformers import (
     DataCollatorForSeq2Seq,
     T5ForConditionalGeneration,
     T5Tokenizer,
-    Trainer,
-    TrainingArguments,
+    Seq2SeqTrainer,
+    Seq2SeqTrainingArguments,
 )
+import numpy as np
+import evaluate
 
 from config import DATA_CSV, MODEL_DIR
 
@@ -47,7 +49,7 @@ def main() -> None:
     tmp_out = Path(f"{MODEL_DIR}_run_{ts}")
 
     dataset = load_dataset("csv", data_files=str(DATA_CSV))["train"].train_test_split(
-        test_size=0.1, seed=42
+        test_size=0.2, seed=42
     )
 
     tokenizer = T5Tokenizer.from_pretrained(MODEL_NAME)
@@ -68,7 +70,18 @@ def main() -> None:
     # Collator handles label padding to -100 automatically for seq2seq
     collator = DataCollatorForSeq2Seq(tokenizer=tokenizer, model=model)
 
-    args = TrainingArguments(
+    accuracy = evaluate.load("accuracy")
+
+    def compute_metrics(eval_pred):
+        preds, labels = eval_pred
+        if isinstance(preds, tuple):
+            preds = preds[0]
+        labels = np.where(labels != -100, labels, tokenizer.pad_token_id)
+        decoded_preds = tokenizer.batch_decode(preds, skip_special_tokens=True)
+        decoded_labels = tokenizer.batch_decode(labels, skip_special_tokens=True)
+        return {"accuracy": accuracy.compute(predictions=decoded_preds, references=decoded_labels)["accuracy"]}
+
+    args = Seq2SeqTrainingArguments(
         output_dir=str(tmp_out),           # write to temp dir
         per_device_train_batch_size=8,
         per_device_eval_batch_size=8,
@@ -81,15 +94,17 @@ def main() -> None:
         fp16=False,
         report_to=[],
         save_safetensors=True,             # set False if you still hit file locks
+        predict_with_generate=True,
     )
 
-    trainer = Trainer(
+    trainer = Seq2SeqTrainer(
         model=model,
         args=args,
         train_dataset=tokenized["train"],
         eval_dataset=tokenized["test"],
         data_collator=collator,
         tokenizer=tokenizer,
+        compute_metrics=compute_metrics,
     )
 
     trainer.train()


### PR DESCRIPTION
## Summary
- track validation accuracy during training with an 80/20 data split
- surface training/validation metrics and Plotly chart in the Gradio training view
- declare Plotly as a dependency

## Testing
- ⚠️ `pip install -r ChatToXml/requirements.txt` (dependency conflict with transformers/optimum)
- ✅ `pip install plotly==5.22.0`
- ✅ `pip install evaluate==0.4.2`
- ✅ `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2ffd4b104832c9a522391e20dfd44