### PR TITLE
Handle missing paths in update operation

### DIFF
--- a/ChatToXml/file_store.py
+++ b/ChatToXml/file_store.py
@@ -32,11 +32,24 @@ def read_zip_file(file_name: str) -> tuple[str, str]:
 
 
 def update_zip_file(file_name: str, source_zip: str) -> str:
-    """Replace the contents of an existing ZIP archive."""
+    """Replace the contents of an existing ZIP archive.
+
+    Returns a helpful message if required paths are missing or invalid.
+    """
+    if not file_name:
+        return "No file name provided."
+    if not source_zip:
+        return "No source path provided."
+
     path = _safe_path(file_name)
     if not path.exists():
         return f"File {path} does not exist."
-    shutil.copy(Path(source_zip), path)
+
+    src_path = Path(source_zip)
+    if not src_path.exists():
+        return f"File {src_path} does not exist."
+
+    shutil.copy(src_path, path)
     return f"Updated {path}"
 
 

--- a/ChatToXml/tests/test_file_store.py
+++ b/ChatToXml/tests/test_file_store.py
@@ -52,3 +52,15 @@ def test_safe_path(monkeypatch, tmp_path):
     file_store.create_zip_file("../evil.zip", str(src_zip))
     # Path traversal should be sanitized
     assert (tmp_path / "evil.zip").exists()
+
+
+def test_update_zip_file_missing_paths(monkeypatch, tmp_path):
+    monkeypatch.setattr(file_store, "OUTPUT_DIR", tmp_path)
+    src_zip = _make_zip(tmp_path, "src.zip")
+    file_store.create_zip_file("archive.zip", str(src_zip))
+
+    missing_src = file_store.update_zip_file("archive.zip", "")
+    assert "No source path provided." in missing_src
+
+    missing_name = file_store.update_zip_file("", str(src_zip))
+    assert "No file name provided." in missing_name


### PR DESCRIPTION
## Summary
- validate file name and source path before updating ZIP archives
- add tests for missing path scenarios

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba28cbee38832c9bc7f2ddc317bd88